### PR TITLE
缓存机制微调

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -157,8 +157,10 @@ function trim(str, len) {
 
 exports.perfectContext = function(context) {
   if (utilx.isExistedFile(context)) {
-    var p = path.resolve(context)
-    ;delete require.cache[p]
+    var p = path.resolve(context);
+    if( require.cache[p] && require.cache[p].exports.cacheable === false ){
+        delete require.cache[p]
+    }    
     context = require(p)
   } else if (utilx.isObject(context)) {
     // do nothing


### PR DESCRIPTION
最近使用 node velocity 的时候遇到的问题，如果我们同时watch了vm模版以及 data数据源，
当我们修改vm模版时，页面会刷新，但是修改模版的数据源data时，虽然页面也刷新了，但是生成的页面还是以前的页面。
最终发现是因为node require模块会自动缓存的问题。
过来提交代码，发现新版的已经添加了删除缓存的机制，这样保证了修改数据源，页面也会对应刷新的效果。
但是感觉大部分情况下缓存还是需要的，这样会稍微提高些效率，毕竟我们修改数据源的情况不多，同时需要修改数据源的页面数量在整个项目中所占的比重也是很小的。

所以默认情况下，数据源是缓存的，如果我们正在开发某个页面，那么在该数据源下添加cacheable字段为false，来满足修改数据源同时刷新页面的需求

好处：提升渲染页面的效率（大部分页面的数据源都走的缓存）
坏处：对指定页面数据源需要添加特定的字段，所以要在说明文档或者教程中“重点”说明，否则别人可能不知道该字段，以及功能