### PR TITLE
deps: upgrade tracer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '4'
-  - '3'
-  - '2'
-  - '1'
+  - '14'
+  - '12'
 script:
   - "npm run test && npm run test-cov"
 after_script:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "colorful": "~2.1.0",
     "commander": "~2.3.0",
-    "tracer": "~0.7.3",
+    "tracer": "~1.1.4",
     "utilx": "0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
tracer@0.7 底层的引用 dateformat 中写的依赖都是用的*，最近 https://github.com/sindresorhus/indent-string 他给所有模块都升级到了 esm，导致报错，升级一下 tracer 避免 broking 的依赖引入。